### PR TITLE
Avoid unexpected completion

### DIFF
--- a/lua/cmp-lua-latex-symbols/complete.lua
+++ b/lua/cmp-lua-latex-symbols/complete.lua
@@ -1,4 +1,8 @@
-return function(_, params, callback)
+return function(self, params, callback)
+    if not vim.regex(self.get_keyword_pattern() .. "$"):match_str(params.context.cursor_before_line) then
+        return callback()
+    end
+
 	local cached = require
 		"cmp-lua-latex-symbols.options".validate(params).cache
 


### PR DESCRIPTION
This aborts completion when there's no leading '\\', which is helpful if you're using a manual trigger for completion.